### PR TITLE
chore(prettier-config): add `prettier@>=3.0.0` to `peerDependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18065,6 +18065,9 @@
                 "prettier-package-json": "2.8.0",
                 "prettier-plugin-organize-attributes": "1.0.0",
                 "sort-package-json": "2.5.1"
+            },
+            "peerDependencies": {
+                "prettier": ">=3.0.0"
             }
         },
         "projects/stylelint-config": {

--- a/projects/prettier-config/package.json
+++ b/projects/prettier-config/package.json
@@ -19,6 +19,9 @@
         "prettier-plugin-organize-attributes": "1.0.0",
         "sort-package-json": "2.5.1"
     },
+    "peerDependencies": {
+        "prettier": ">=3.0.0"
+    },
     "publishConfig": {
         "access": "public"
     }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [X] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?
Use `prettier@2`.
It will throw:

```
projects/react/package.json
[error] projects/react/package.json: Error: unknown type: undefined
[error]     at Object.genericPrint [as print] (/Users/n.barsukov/WebstormProjects/maskito/node_modules/prettier/index.js:30111:17)
[error]     at callPluginPrintFunction (/Users/n.barsukov/WebstormProjects/maskito/node_modules/prettier/index.js:8601:26)
[error]     at mainPrintInternal (/Users/n.barsukov/WebstormProjects/maskito/node_modules/prettier/index.js:8550:22)
[error]     at /Users/n.barsukov/WebstormProjects/maskito/node_modules/prettier/index.js:8542:32
[error]     at AstPath.call (/Users/n.barsukov/WebstormProjects/maskito/node_modules/prettier/index.js:8359:24)
[error]     at mainPrint (/Users/n.barsukov/WebstormProjects/maskito/node_modules/prettier/index.js:8542:21)
[error]     at Object.genericPrint [as print] (/Users/n.barsukov/WebstormProjects/maskito/node_modules/prettier/index.js:30082:19)
[error]     at callPluginPrintFunction (/Users/n.barsukov/WebstormProjects/maskito/node_modules/prettier/index.js:8601:26)
[error]     at mainPrintInternal (/Users/n.barsukov/WebstormProjects/maskito/node_modules/prettier/index.js:8550:22)
[error]     at mainPrint (/Users/n.barsukov/WebstormProjects/maskito/node_modules/prettier/index.js:8537:18)
```
