### PR TITLE
feat(eslint-plugin-experience): add autofix for `decorator-key-sort` rule

### DIFF
--- a/projects/eslint-plugin-experience/all.js
+++ b/projects/eslint-plugin-experience/all.js
@@ -131,6 +131,7 @@ module.exports = {
                             'interpolation',
                         ],
                         Directive: [
+                            'standalone',
                             'selector',
                             'inputs',
                             'outputs',


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the new behaviour?
**eslint.config.js**
```js
'@taiga-ui/experience/decorator-key-sort': [
    'error',
    {
        Component: [
            'standalone',
            'selector',
            'providers',
            'templateUrl',
            'styleUrls',
            'changeDetection',
        ],
    }
]
```

Run `eslint . --fix`

<img width="1192" alt="Screenshot 2023-12-08 at 19 58 14" src="https://github.com/taiga-family/linters/assets/35179038/c1ad5b62-52e6-413e-9605-c8657e50a3c1">


