### PR TITLE
feat(eslint-plugin-experience): add `unicorn/prefer-string-replace-all` rule

### DIFF
--- a/projects/eslint-plugin-experience/all.js
+++ b/projects/eslint-plugin-experience/all.js
@@ -682,6 +682,7 @@ module.exports = {
                 'unicorn/no-unsafe-regex': 'error',
                 'unicorn/no-useless-spread': 'error',
                 'unicorn/prefer-logical-operator-over-ternary': 'error',
+                'unicorn/prefer-string-replace-all': 'error',
                 'unicorn/prefer-string-slice': 'error',
                 'unicorn/require-number-to-fixed-digits-argument': 'error',
                 'vars-on-top': 'error',


### PR DESCRIPTION
> The [String#replaceAll()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll) method is both faster and safer as you don't have to use a regex and remember to escape it if the string is not a literal. And when used with a regex, it makes the intent clearer.

**Learn more:**
* https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-replace-all.md
* https://github.com/taiga-family/taiga-ui/pull/6828