### PR TITLE
fix(eslint-plugin-experience): add alias `takeUntilDestroyed` to `rxjs/no-unsafe-takeuntil` rule

### DIFF
--- a/projects/eslint-plugin-experience/all.js
+++ b/projects/eslint-plugin-experience/all.js
@@ -712,6 +712,12 @@ module.exports = {
                 'rxjs/no-unsafe-catch': 'error',
                 'rxjs/no-unsafe-first': 'error',
                 'rxjs/no-unsafe-switchmap': 'error',
+                "rxjs/no-unsafe-takeuntil": [
+                    "error",
+                    {
+                        "alias": ["takeUntilDestroyed"]
+                    }
+                ],
                 'rxjs/throw-error': 'error',
                 'simple-import-sort/exports': 'error',
                 'simple-import-sort/imports': 'error',


### PR DESCRIPTION
# Previous behaviour 

<img width="1425" alt="no-unsafe-takeuntil" src="https://github.com/taiga-family/linters/assets/35179038/4e243f99-fdef-499a-9d0b-cf07c9bb2e5d">

# New behaviour
<img width="1046" alt="Снимок экрана 2024-03-20 в 12 44 03" src="https://github.com/taiga-family/linters/assets/35179038/f2d9f1d3-2b3c-4a89-8ef9-690d72bc4764">


Learn more:
https://github.com/cartant/eslint-plugin-rxjs/blob/main/docs/rules/no-unsafe-takeuntil.md#options