### PR TITLE
fix(eslint-plugin-experience): add Windows OS support for `prefer-deep-imports` rule

### DIFF
--- a/projects/eslint-plugin-experience/rules/prefer-deep-imports.js
+++ b/projects/eslint-plugin-experience/rules/prefer-deep-imports.js
@@ -27,18 +27,25 @@ module.exports = {
                         );
                         const importedEntitiesSourceFiles = importedEntities.map(
                             ({imported}) =>
-                                allTsFiles.find(path => {
-                                    const fileContent = fs.readFileSync(path, 'utf8');
+                                allTsFiles
+                                    .find(path => {
+                                        const fileContent = fs.readFileSync(path, 'utf8');
 
-                                    return fileContent.match(
-                                        new RegExp(
-                                            `(?<=export\\s(default\\s)?(abstract\\s)?\\w+\\s)\\b${imported.name}\\b`,
-                                        ),
-                                    );
-                                }),
+                                        return fileContent.match(
+                                            new RegExp(
+                                                `(?<=export\\s(default\\s)?(abstract\\s)?\\w+\\s)\\b${imported.name}\\b`,
+                                            ),
+                                        );
+                                    })
+                                    .replace(/\\+/g, '/'), // Windows path to Unix path,
                         );
                         const entryPoints =
                             importedEntitiesSourceFiles.map(findNearestEntryPoint);
+
+                        if (entryPoints.some(e => !e)) {
+                            return; // to prevent `import {A,B,C} from 'undefined';`
+                        }
+
                         const newImports = importedEntities.map(
                             ({imported, local}, i) => {
                                 const importedEntity =

--- a/projects/eslint-plugin-experience/rules/prefer-deep-imports.js
+++ b/projects/eslint-plugin-experience/rules/prefer-deep-imports.js
@@ -37,7 +37,7 @@ module.exports = {
                                             ),
                                         );
                                     })
-                                    .replaceAll(/\\+/g, '/'), // Windows path to Unix path,
+                                    ?.replaceAll(/\\+/g, '/'), // Windows path to Unix path,
                         );
                         const entryPoints =
                             importedEntitiesSourceFiles.map(findNearestEntryPoint);

--- a/projects/eslint-plugin-experience/rules/prefer-deep-imports.js
+++ b/projects/eslint-plugin-experience/rules/prefer-deep-imports.js
@@ -37,7 +37,7 @@ module.exports = {
                                             ),
                                         );
                                     })
-                                    .replace(/\\+/g, '/'), // Windows path to Unix path,
+                                    .replaceAll(/\\+/g, '/'), // Windows path to Unix path,
                         );
                         const entryPoints =
                             importedEntitiesSourceFiles.map(findNearestEntryPoint);


### PR DESCRIPTION
```
import {tuiCreateToken} from '@taiga-ui/cdk';
import {TUI_THEME, TuiDataList} from '@taiga-ui/core';
import {TuiSelectModule} from '@taiga-ui/legacy';
```
⬇️ 

```
import {TUI_THEME, tuiCreateToken, TuiDataList, TuiSelectModule} from 'undefined'
```